### PR TITLE
Fix feed playlist query to match follow schema

### DIFF
--- a/app/api/v1/endpoints/playlists.py
+++ b/app/api/v1/endpoints/playlists.py
@@ -31,11 +31,16 @@ def read_feed(
     current_user: User = Depends(get_current_user)
 ):
     # Get playlists from followed users
-    following_ids = db.query(Follow.followed_id).filter(Follow.follower_id == current_user.id).all()
+    following_ids = db.query(Follow.following_id).filter(
+        Follow.follower_id == current_user.id
+    ).all()
     following_ids = [f[0] for f in following_ids]
 
+    if not following_ids:
+        return []
+
     playlists = db.query(Playlist).filter(
-        Playlist.owner_id.in_(following_ids)
+        Playlist.user_id.in_(following_ids)
     ).order_by(desc(Playlist.created_at)).offset(skip).limit(limit).all()
 
     return playlists


### PR DESCRIPTION
## Summary
- query followed users using `following_id` and filter playlists by `user_id` to match schema
- return an empty list when no followees are present to avoid invalid filters

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69349b4aae38832a90e2bec29c704355)