### PR TITLE
Add configuration settings tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,4 +26,6 @@ build-backend = "hatchling.build"
 packages = ["app"]
 
 [dependency-groups]
-dev = []
+dev = [
+    "pytest>=7.0",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+import os
+
+# Ensure the application package is importable when running tests without installation
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+# Provide required defaults for settings instantiation during module import
+os.environ.setdefault("SECRET_KEY", "test-secret-key")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,51 @@
+import pytest
+
+from app.core.config import Settings
+
+
+def make_settings(**overrides) -> Settings:
+    base_settings = {
+        "SECRET_KEY": "test-secret-key",
+        "POSTGRES_USER": "postgres",
+        "POSTGRES_PASSWORD": "postgres",
+        "POSTGRES_SERVER": "localhost",
+        "POSTGRES_PORT": "5432",
+        "POSTGRES_DB": "soundpuff",
+    }
+    base_settings.update(overrides)
+    return Settings(**base_settings)
+
+
+def test_cors_origins_are_split_into_list():
+    settings = make_settings(
+        BACKEND_CORS_ORIGINS="http://localhost:3000,http://example.com",
+    )
+
+    assert [str(origin) for origin in settings.BACKEND_CORS_ORIGINS] == [
+        "http://localhost:3000/",
+        "http://example.com/",
+    ]
+
+
+def test_db_url_defaults_to_local_postgres_connection():
+    settings = make_settings()
+
+    assert (
+        settings.db_url
+        == "postgresql+psycopg2://postgres:postgres@localhost:5432/soundpuff"
+    )
+
+
+def test_supabase_database_url_is_used_when_provided():
+    custom_database_url = "postgresql+psycopg2://user:password@host:5432/customdb"
+    settings = make_settings(
+        SUPABASE_URL="https://example.supabase.co",
+        DATABASE_URL=custom_database_url,
+    )
+
+    assert settings.db_url == custom_database_url
+
+
+def test_invalid_database_url_raises_value_error():
+    with pytest.raises(ValueError):
+        make_settings(DATABASE_URL="not-a-valid-database-url")


### PR DESCRIPTION
## Summary
- add pytest to dev dependency group for running unit tests
- add fixtures to make the application package importable during tests with a default secret key
- cover Settings behaviors for CORS parsing, database URL selection, and invalid URL validation

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69349d6bcc30832aa6dd8e277e0df7ef)