### PR TITLE
Add playlist privacy settings

### DIFF
--- a/app/api/v1/endpoints/playlists.py
+++ b/app/api/v1/endpoints/playlists.py
@@ -1,9 +1,9 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from sqlalchemy import desc
-from typing import List
+from sqlalchemy import desc, or_
+from typing import List, Optional
 
-from app.core.deps import get_current_user
+from app.core.deps import get_current_user, get_current_user_optional
 from app.db.session import get_db
 from app.models import User, Playlist, Like, Comment, Follow
 from app.schemas.playlist import Playlist as PlaylistSchema, PlaylistCreate, PlaylistUpdate
@@ -13,13 +13,29 @@ from app.schemas.comment import Comment as CommentSchema, CommentCreate, Comment
 router = APIRouter()
 
 
+def _ensure_playlist_accessible(playlist: Playlist, current_user: Optional[User]):
+    if playlist.privacy == "private" and (current_user is None or playlist.user_id != current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This playlist is private"
+        )
+
+
 @router.get("/", response_model=List[PlaylistSchema])
 def read_playlists(
     skip: int = 0,
     limit: int = 20,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    current_user: Optional[User] = Depends(get_current_user_optional)
 ):
-    playlists = db.query(Playlist).order_by(desc(Playlist.created_at)).offset(skip).limit(limit).all()
+    query = db.query(Playlist)
+
+    if current_user is None:
+        query = query.filter(Playlist.privacy == "public")
+    else:
+        query = query.filter(or_(Playlist.privacy == "public", Playlist.user_id == current_user.id))
+
+    playlists = query.order_by(desc(Playlist.created_at)).offset(skip).limit(limit).all()
     return playlists
 
 
@@ -41,6 +57,8 @@ def read_feed(
 
     playlists = db.query(Playlist).filter(
         Playlist.user_id.in_(following_ids)
+    ).filter(
+        or_(Playlist.privacy == "public", Playlist.user_id == current_user.id)
     ).order_by(desc(Playlist.created_at)).offset(skip).limit(limit).all()
 
     return playlists
@@ -63,13 +81,18 @@ def create_playlist(
 
 
 @router.get("/{playlist_id}", response_model=PlaylistSchema)
-def read_playlist(playlist_id: int, db: Session = Depends(get_db)):
+def read_playlist(
+    playlist_id: int,
+    db: Session = Depends(get_db),
+    current_user: Optional[User] = Depends(get_current_user_optional)
+):
     playlist = db.query(Playlist).filter(Playlist.id == playlist_id).first()
     if not playlist:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Playlist not found"
         )
+    _ensure_playlist_accessible(playlist, current_user)
     return playlist
 
 
@@ -99,6 +122,8 @@ def update_playlist(
         playlist.title = playlist_in.title
     if playlist_in.description is not None:
         playlist.description = playlist_in.description
+    if playlist_in.privacy is not None:
+        playlist.privacy = playlist_in.privacy
     # Removed cover image handling (no longer supported)
 
     db.commit()
@@ -145,6 +170,8 @@ def like_playlist(
             detail="Playlist not found"
         )
 
+    _ensure_playlist_accessible(playlist, current_user)
+
     # Check if already liked
     existing_like = db.query(Like).filter(
         Like.user_id == current_user.id,
@@ -189,7 +216,20 @@ def unlike_playlist(
 
 
 @router.get("/{playlist_id}/comments", response_model=List[CommentSchema])
-def read_playlist_comments(playlist_id: int, db: Session = Depends(get_db)):
+def read_playlist_comments(
+    playlist_id: int,
+    db: Session = Depends(get_db),
+    current_user: Optional[User] = Depends(get_current_user_optional)
+):
+    playlist = db.query(Playlist).filter(Playlist.id == playlist_id).first()
+    if not playlist:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Playlist not found"
+        )
+
+    _ensure_playlist_accessible(playlist, current_user)
+
     comments = db.query(Comment).filter(
         Comment.playlist_id == playlist_id
     ).order_by(desc(Comment.created_at)).all()
@@ -210,6 +250,8 @@ def create_comment(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Playlist not found"
         )
+
+    _ensure_playlist_accessible(playlist, current_user)
 
     comment = Comment(
         body=comment_in.body,

--- a/app/core/deps.py
+++ b/app/core/deps.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from typing import Generator, Optional
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from jose import jwt, JWTError
@@ -13,6 +13,7 @@ from app.models import User
 
 # Use HTTPBearer instead of OAuth2PasswordBearer since we're using Supabase Auth
 security = HTTPBearer()
+optional_security = HTTPBearer(auto_error=False)
 
 
 def get_supabase_client() -> Client:
@@ -60,6 +61,54 @@ def get_current_user(
 
     except ValueError as e:
         # Invalid UUID
+        raise credentials_exception
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Invalid authentication credentials: {str(e)}",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+def get_current_user_optional(
+    db: Session = Depends(get_db),
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(optional_security),
+    supabase: Client = Depends(get_supabase_client)
+) -> Optional[User]:
+    """
+    Return the current user if a valid token is provided, otherwise None.
+    """
+    if credentials is None:
+        return None
+
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    token = credentials.credentials
+
+    try:
+        user_response = supabase.auth.get_user(token)
+
+        if not user_response or not user_response.user:
+            raise credentials_exception
+
+        supabase_user = user_response.user
+        user_id = UUID(supabase_user.id)
+
+        user = db.query(User).filter(User.id == user_id).first()
+
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="User profile not found. Please create a profile first."
+            )
+
+        return user
+
+    except ValueError:
         raise credentials_exception
     except Exception as e:
         raise HTTPException(

--- a/app/models/playlist.py
+++ b/app/models/playlist.py
@@ -12,6 +12,7 @@ class Playlist(Base):
     id = Column(BigInteger, primary_key=True, index=True, autoincrement=True)
     title = Column(String(100), nullable=False)
     description = Column(Text, nullable=True)
+    privacy = Column(String(20), nullable=False, server_default="public", default="public")
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/app/schemas/playlist.py
+++ b/app/schemas/playlist.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Optional, List
+from typing import Optional, List, Literal
 from datetime import datetime
 from uuid import UUID
 from app.schemas.user import User
@@ -9,6 +9,7 @@ from app.schemas.song import Song
 class PlaylistBase(BaseModel):
     title: str
     description: Optional[str] = None
+    privacy: Literal["public", "private"] = "public"
 
 
 class PlaylistCreate(PlaylistBase):
@@ -18,12 +19,14 @@ class PlaylistCreate(PlaylistBase):
 class PlaylistUpdate(BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
+    privacy: Optional[Literal["public", "private"]] = None
     
 
 
 class PlaylistInDB(PlaylistBase):
     id: int
     user_id: UUID
+    privacy: Literal["public", "private"]
     created_at: datetime
     updated_at: Optional[datetime] = None
 


### PR DESCRIPTION
## Summary
- add a privacy field to playlists and expose it through API schemas
- enforce privacy rules across playlist listing, feed, retrieval, comments, and likes
- add an optional authentication dependency to support private playlist checks without requiring auth for public content

## Testing
- pytest

------