### PR TITLE
Normalize legacy playlist privacy values to 'public'/'private' and ad…

### DIFF
--- a/app/api/v1/endpoints/playlists.py
+++ b/app/api/v1/endpoints/playlists.py
@@ -25,6 +25,45 @@ def _ensure_playlist_accessible(playlist: Playlist, current_user: Optional[User]
         )
 
 
+def _normalize_privacy(playlist: Playlist):
+    """Ensure `playlist.privacy` is a string of either 'public' or 'private'.
+
+    Some legacy rows may store privacy as booleans, ints (0/1), or other
+    variants; normalize those to the expected literal strings so Pydantic
+    validation succeeds.
+    """
+    try:
+        priv = playlist.privacy
+    except Exception:
+        return playlist
+
+    # If already valid string, keep it
+    if isinstance(priv, str):
+        s = priv.strip().lower()
+        if s in ("public", "private"):
+            playlist.privacy = s
+            return playlist
+        if s in ("true", "t", "1", "yes"):
+            playlist.privacy = "public"
+            return playlist
+        if s in ("false", "f", "0", "no"):
+            playlist.privacy = "private"
+            return playlist
+        # Unexpected string - fallthrough to default
+
+    # Convert booleans and numeric values
+    if isinstance(priv, bool):
+        playlist.privacy = "public" if priv else "private"
+    elif isinstance(priv, (int, float)):
+        playlist.privacy = "public" if int(priv) != 0 else "private"
+    elif priv is None:
+        playlist.privacy = "public"
+    else:
+        # Last resort default
+        playlist.privacy = "public"
+    return playlist
+
+
 @router.get("/", response_model=List[PlaylistSchema])
 def read_playlists(
     skip: int = 0,
@@ -40,6 +79,8 @@ def read_playlists(
         query = query.filter(or_(Playlist.privacy == "public", Playlist.user_id == current_user.id))
 
     playlists = query.order_by(desc(Playlist.created_at)).offset(skip).limit(limit).all()
+    for p in playlists:
+        _normalize_privacy(p)
     return playlists
 
 
@@ -66,6 +107,8 @@ def read_feed(
         or_(Playlist.privacy == "public", Playlist.user_id == current_user.id)
     ).order_by(desc(Playlist.created_at)).offset(skip).limit(limit).all()
 
+    for p in playlists:
+        _normalize_privacy(p)
     return playlists
 
 
@@ -82,6 +125,7 @@ def create_playlist(
     db.add(playlist)
     db.commit()
     db.refresh(playlist)
+    _normalize_privacy(playlist)
     return playlist
 
 
@@ -100,6 +144,7 @@ def read_playlist(
     _ensure_playlist_accessible(playlist, current_user)
     playlist.likes_count = len(playlist.likes)
     playlist.comments_count = len(playlist.comments)
+    _normalize_privacy(playlist)
     return playlist
 
 
@@ -135,6 +180,7 @@ def update_playlist(
 
     db.commit()
     db.refresh(playlist)
+    _normalize_privacy(playlist)
     return playlist
 
 
@@ -316,6 +362,7 @@ def add_song_to_playlist(
     playlist.songs.append(song)
     db.commit()
     db.refresh(playlist)
+    _normalize_privacy(playlist)
     return playlist
 
 

--- a/tests/test_playlists.py
+++ b/tests/test_playlists.py
@@ -196,6 +196,49 @@ def test_list_playlists_pagination(client, current_user, db_session):
     assert len(resp.json()) == 2
 
 
+def test_boolean_privacy_is_normalized_to_private(client, db_session, current_user):
+    """Legacy boolean False privacy should be normalized to 'private' in responses."""
+    # Insert playlist with boolean False privacy directly in DB
+    playlist = Playlist(
+        id=_get_next_playlist_id(),
+        title="Bool Privacy Private",
+        description="boolean privacy false",
+        privacy=False,
+        user_id=current_user.id
+    )
+    db_session.add(playlist)
+    db_session.flush()
+    db_session.refresh(playlist)
+
+    app.dependency_overrides[get_current_user_optional] = lambda: current_user
+    resp = client.get("/api/v1/playlists/")
+    assert resp.status_code == 200
+    found = next((p for p in resp.json() if p["title"] == "Bool Privacy Private"), None)
+    assert found is not None
+    assert found["privacy"] == "private"
+
+
+def test_boolean_privacy_is_normalized_to_public(client, db_session, current_user):
+    """Legacy boolean True privacy should be normalized to 'public' in responses."""
+    playlist = Playlist(
+        id=_get_next_playlist_id(),
+        title="Bool Privacy Public",
+        description="boolean privacy true",
+        privacy=True,
+        user_id=current_user.id
+    )
+    db_session.add(playlist)
+    db_session.flush()
+    db_session.refresh(playlist)
+
+    app.dependency_overrides[get_current_user_optional] = lambda: current_user
+    resp = client.get("/api/v1/playlists/")
+    assert resp.status_code == 200
+    found = next((p for p in resp.json() if p["title"] == "Bool Privacy Public"), None)
+    assert found is not None
+    assert found["privacy"] == "public"
+
+
 # ==================== GET /feed tests ====================
 
 


### PR DESCRIPTION
…d tests

Add _normalize_privacy helper to playlist endpoints to coerce boolean/int/string values into the Pydantic-expected literals and call it before returning playlists. Add tests to verify boolean privacy normalization.